### PR TITLE
Allow for piping input, add pragmas for module code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function createStream(path, options) {
     }))
   })
 
-  return glslify(path, !!options.is_input, {
+  return glslify(path, !!options.input, {
     transform: transforms
   })
 }
@@ -65,22 +65,22 @@ function glslify(path, is_input, options, base, module_id, mappings, define_in_p
   registry = registry || {}
   counter = counter || shortest()
 
-  var input_stream = options.is_input
-    ? through()
-    : fs.createReadStream(path)
-
   var prefix = module_id === '.'
     ? '#define GLSLIFY 1\n\n\n'
     : ''
 
   var output_stream = combine(
-      input_stream
-    , transform(path, in_node_modules, transforms)
+      transform(path, in_node_modules, transforms)
     , wrap(prefix)
     , token_stream
     , parser_stream
     , stream
   )
+
+  if(!is_input) {
+    fs.createReadStream(path)
+      .pipe(output_stream)
+  }
 
   return output_stream
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "through": "~1.1.2",
     "commondir": "0.0.1",
     "stream-combiner": "0.0.2",
+    "resolve": "~0.5.1",
     "wrap-stream": "0.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,14 @@
     "glsl-parser": "~0.0.4",
     "glsl-tokenizer": "~0.0.8",
     "shortest": "~0.0.0",
-    "through": "~1.1.2"
+    "through": "~1.1.2",
+    "commondir": "0.0.1",
+    "stream-combiner": "0.0.2",
+    "wrap-stream": "0.0.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "glsl-deparser": "0.0.2"
+  },
   "scripts": {
     "test": "node test/index.js"
   },


### PR DESCRIPTION
@chrisdickinson understand you're probably not keen on maintaining this set of modules - would be good to hear your thoughts. I'd be happy to either maintain the repo or fork the project if that's the case :)

The first change is to optionally enable piping text into glslify-stream instead of reading the file directly. A second boolean argument is added to the function such that:

``` javascript
require('glslify-stream')('path', true)
```

Will not read the file and return a through stream
for writing to.

The second is to add pragmas to specify module start/end points.

node_modules begin with:

``` glsl
#pragma glslify_file start module
```

And other external files:

``` glsl
#pragma glslify_file start
```

Both types of files end with:

``` glsl
#pragma glslify_file end
```

These two changes make it possible to add browserify-style transform streams to glslify, in that they can be piped
in a chain and ignore module code.
